### PR TITLE
Add EnableLoopIdiom to PassManagerBuilder to control loop-idiom pass execution in PassManagerBuilder

### DIFF
--- a/include/llvm/Transforms/IPO/PassManagerBuilder.h
+++ b/include/llvm/Transforms/IPO/PassManagerBuilder.h
@@ -137,6 +137,7 @@ public:
   bool PrepareForLTO;
   bool PrepareForThinLTO;
   bool PerformThinLTO;
+  bool EnableLoopIdiom;
 
   /// Profile data file name that the instrumentation will be written to.
   std::string PGOInstrGen;

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -160,6 +160,7 @@ PassManagerBuilder::PassManagerBuilder() {
     PGOInstrUse = RunPGOInstrUse;
     PrepareForThinLTO = false;
     PerformThinLTO = false;
+    EnableLoopIdiom = true;
 }
 
 PassManagerBuilder::~PassManagerBuilder() {
@@ -291,7 +292,8 @@ void PassManagerBuilder::addFunctionSimplificationPasses(
   MPM.add(createCFGSimplificationPass());
   addInstructionCombiningPass(MPM);
   MPM.add(createIndVarSimplifyPass());        // Canonicalize indvars
-  MPM.add(createLoopIdiomPass());             // Recognize idioms like memset.
+  if (EnableLoopIdiom)
+    MPM.add(createLoopIdiomPass());       // Recognize idioms like memset.
   MPM.add(createLoopDeletionPass());          // Delete dead loops
   if (EnableLoopInterchange) {
     MPM.add(createLoopInterchangePass()); // Interchange loops


### PR DESCRIPTION
Add EnableLoopIdiom flag to separate host and device
compilation. While compiling kernel code, do not execute loop idiom
pass to avoid llvm.memcpy intrinsics to have different address pointer
source and destination.