### PR TITLE
 Add the DEBUG macro to dump() method in remove_global_empty_cdtors.cpp

### DIFF
--- a/lib/SYCL/remove_global_empty_cdtors.cpp
+++ b/lib/SYCL/remove_global_empty_cdtors.cpp
@@ -84,7 +84,7 @@ bool removeEmptyGlobalArray(Module &M,
   auto GL = M.getGlobalVariable(GlobalVariableName);
   if (GL) {
     DEBUG(errs() << "Found " << GlobalVariableName << "\n\n");
-    GL->getType()->dump();
+    DEBUG(GL->getType()->dump());
     if (auto PT = dyn_cast<PointerType>(GL->getType()))
       // If it is an array, try to get the pointee array
       if (auto AT = dyn_cast<ArrayType>(PT->getElementType()))


### PR DESCRIPTION
When triSYCL is in debug mode but LLVM is compiled in release mode.
The dump() method fails compilation.
Add DEBUG macro to solve this problem.